### PR TITLE
feat: Implement GenericEncryptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ func CreateEncryptor(ctx context.Context) (*cloudencrypt.Encryptor, error) {
 		return nil, err
 	}
 
-	encryptor, err := cloudencrypt.NewGCPEncryptor(ctx, os.Getenv("GCP_KMS_KEY_ID"))
+	var encryptor cloudencrypt.Encryptor
+
+	encryptor, err = cloudencrypt.NewGCPEncryptor(ctx, os.Getenv("GCP_KMS_KEY_ID"))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/encode/encode_test.go
+++ b/internal/encode/encode_test.go
@@ -1,10 +1,11 @@
-package encode
+package encode_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/keboola/go-cloud-encrypt/internal/encode"
 	"github.com/keboola/go-cloud-encrypt/internal/random"
 )
 
@@ -17,11 +18,11 @@ func TestEncodeDecode(t *testing.T) {
 	data := make(map[string][]byte)
 	data["test"] = secretKey
 
-	encoded, err := Encode(data)
+	encoded, err := encode.Encode(data)
 	assert.NoError(t, err)
 	assert.NotNil(t, encoded)
 
-	decoded, err := Decode[map[string][]byte](encoded)
+	decoded, err := encode.Decode[map[string][]byte](encoded)
 	assert.NoError(t, err)
 	assert.NotNil(t, decoded)
 

--- a/pkg/cloudencrypt/aws_test.go
+++ b/pkg/cloudencrypt/aws_test.go
@@ -1,4 +1,4 @@
-package cloudencrypt
+package cloudencrypt_test
 
 import (
 	"context"
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/keboola/go-cloud-encrypt/pkg/cloudencrypt"
 )
 
 func TestAWSEncryptor(t *testing.T) {
@@ -24,16 +26,16 @@ func TestAWSEncryptor(t *testing.T) {
 		require.Fail(t, "AWS_KMS_KEY_ID is empty")
 	}
 
-	encryptor, err := NewAWSEncryptor(ctx, region, keyID)
+	encryptor, err := cloudencrypt.NewAWSEncryptor(ctx, region, keyID)
 	require.NoError(t, err)
 
-	meta := Metadata{}
+	meta := cloudencrypt.Metadata{}
 	meta["metakey"] = "metavalue"
 
 	ciphertext, err := encryptor.Encrypt(ctx, []byte("Lorem ipsum"), meta)
 	require.NoError(t, err)
 
-	_, err = encryptor.Decrypt(ctx, ciphertext, Metadata{})
+	_, err = encryptor.Decrypt(ctx, ciphertext, cloudencrypt.Metadata{})
 	assert.ErrorContains(t, err, "aws decryption failed: operation error KMS: Decrypt")
 
 	plaintext, err := encryptor.Decrypt(ctx, ciphertext, meta)

--- a/pkg/cloudencrypt/azure_test.go
+++ b/pkg/cloudencrypt/azure_test.go
@@ -1,4 +1,4 @@
-package cloudencrypt
+package cloudencrypt_test
 
 import (
 	"context"
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/keboola/go-cloud-encrypt/pkg/cloudencrypt"
 )
 
 func TestAzureEncryptor(t *testing.T) {
@@ -24,19 +26,19 @@ func TestAzureEncryptor(t *testing.T) {
 		require.Fail(t, "AZURE_KEY_NAME is empty")
 	}
 
-	azureEncryptor, err := NewAzureEncryptor(ctx, vaultURL, keyName)
+	azureEncryptor, err := cloudencrypt.NewAzureEncryptor(ctx, vaultURL, keyName)
 	require.NoError(t, err)
 
-	encryptor, err := NewDualEncryptor(ctx, azureEncryptor)
+	encryptor, err := cloudencrypt.NewDualEncryptor(ctx, azureEncryptor)
 	require.NoError(t, err)
 
-	meta := Metadata{}
+	meta := cloudencrypt.Metadata{}
 	meta["metakey"] = "metavalue"
 
 	ciphertext, err := encryptor.Encrypt(ctx, []byte("Lorem ipsum"), meta)
 	require.NoError(t, err)
 
-	_, err = encryptor.Decrypt(ctx, ciphertext, Metadata{})
+	_, err = encryptor.Decrypt(ctx, ciphertext, cloudencrypt.Metadata{})
 	assert.ErrorContains(t, err, "decryption failed")
 
 	plaintext, err := encryptor.Decrypt(ctx, ciphertext, meta)

--- a/pkg/cloudencrypt/cached_test.go
+++ b/pkg/cloudencrypt/cached_test.go
@@ -1,4 +1,4 @@
-package cloudencrypt
+package cloudencrypt_test
 
 import (
 	"bytes"
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keboola/go-cloud-encrypt/internal/random"
+	"github.com/keboola/go-cloud-encrypt/pkg/cloudencrypt"
 )
 
 func TestCachedEncryptor(t *testing.T) {
@@ -22,13 +23,13 @@ func TestCachedEncryptor(t *testing.T) {
 	secretKey, err := random.SecretKey()
 	assert.NoError(t, err)
 
-	nativeEncryptor, err := NewNativeEncryptor(secretKey)
+	nativeEncryptor, err := cloudencrypt.NewNativeEncryptor(secretKey)
 	assert.NoError(t, err)
 
 	var buffer bytes.Buffer
 	logger := log.New(&buffer, "", 0)
 
-	logEncryptor, err := NewLoggedEncryptor(ctx, nativeEncryptor, logger)
+	logEncryptor, err := cloudencrypt.NewLoggedEncryptor(ctx, nativeEncryptor, logger)
 	assert.NoError(t, err)
 
 	config := &ristretto.Config[[]byte, []byte]{
@@ -40,7 +41,7 @@ func TestCachedEncryptor(t *testing.T) {
 	cache, err := ristretto.NewCache(config)
 	assert.NoError(t, err)
 
-	encryptor, err := NewCachedEncryptor(
+	encryptor, err := cloudencrypt.NewCachedEncryptor(
 		ctx,
 		logEncryptor,
 		time.Hour,
@@ -48,7 +49,7 @@ func TestCachedEncryptor(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	meta := Metadata{}
+	meta := cloudencrypt.Metadata{}
 	meta["metakey"] = "metavalue"
 
 	ciphertext, err := encryptor.Encrypt(ctx, []byte("Lorem ipsum"), meta)
@@ -57,7 +58,7 @@ func TestCachedEncryptor(t *testing.T) {
 	// Wait for cached item to be available for get operations
 	cache.Wait()
 
-	_, err = encryptor.Decrypt(ctx, ciphertext, Metadata{})
+	_, err = encryptor.Decrypt(ctx, ciphertext, cloudencrypt.Metadata{})
 	assert.ErrorContains(t, err, "cipher: message authentication failed")
 
 	plaintext, err := encryptor.Decrypt(ctx, ciphertext, meta)

--- a/pkg/cloudencrypt/dual_test.go
+++ b/pkg/cloudencrypt/dual_test.go
@@ -1,4 +1,4 @@
-package cloudencrypt
+package cloudencrypt_test
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keboola/go-cloud-encrypt/internal/random"
+	"github.com/keboola/go-cloud-encrypt/pkg/cloudencrypt"
 )
 
 func TestDualEncryptor(t *testing.T) {
@@ -17,19 +18,19 @@ func TestDualEncryptor(t *testing.T) {
 	secretKey, err := random.SecretKey()
 	assert.NoError(t, err)
 
-	nativeEncryptor, err := NewNativeEncryptor(secretKey)
+	nativeEncryptor, err := cloudencrypt.NewNativeEncryptor(secretKey)
 	assert.NoError(t, err)
 
-	encryptor, err := NewDualEncryptor(ctx, nativeEncryptor)
+	encryptor, err := cloudencrypt.NewDualEncryptor(ctx, nativeEncryptor)
 	assert.NoError(t, err)
 
-	meta := Metadata{}
+	meta := cloudencrypt.Metadata{}
 	meta["metakey"] = "metavalue"
 
 	ciphertext, err := encryptor.Encrypt(ctx, []byte("Lorem ipsum"), meta)
 	assert.NoError(t, err)
 
-	_, err = encryptor.Decrypt(ctx, ciphertext, Metadata{})
+	_, err = encryptor.Decrypt(ctx, ciphertext, cloudencrypt.Metadata{})
 	assert.ErrorContains(t, err, "cipher: message authentication failed")
 
 	plaintext, err := encryptor.Decrypt(ctx, ciphertext, meta)

--- a/pkg/cloudencrypt/gcp_test.go
+++ b/pkg/cloudencrypt/gcp_test.go
@@ -1,4 +1,4 @@
-package cloudencrypt
+package cloudencrypt_test
 
 import (
 	"context"
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/keboola/go-cloud-encrypt/pkg/cloudencrypt"
 )
 
 func TestGCPEncryptor(t *testing.T) {
@@ -19,16 +21,16 @@ func TestGCPEncryptor(t *testing.T) {
 		require.Fail(t, "GCP_KMS_KEY_ID is empty")
 	}
 
-	encryptor, err := NewGCPEncryptor(ctx, keyID)
+	encryptor, err := cloudencrypt.NewGCPEncryptor(ctx, keyID)
 	require.NoError(t, err)
 
-	meta := Metadata{}
+	meta := cloudencrypt.Metadata{}
 	meta["metakey"] = "metavalue"
 
 	ciphertext, err := encryptor.Encrypt(ctx, []byte("Lorem ipsum"), meta)
 	require.NoError(t, err)
 
-	_, err = encryptor.Decrypt(ctx, ciphertext, Metadata{})
+	_, err = encryptor.Decrypt(ctx, ciphertext, cloudencrypt.Metadata{})
 	assert.ErrorContains(t, err, "gcp decryption failed: rpc error: code = InvalidArgument")
 
 	plaintext, err := encryptor.Decrypt(ctx, ciphertext, meta)

--- a/pkg/cloudencrypt/generic.go
+++ b/pkg/cloudencrypt/generic.go
@@ -1,0 +1,43 @@
+package cloudencrypt
+
+import (
+	"context"
+
+	"github.com/keboola/go-cloud-encrypt/internal/encode"
+)
+
+type GenericEncryptor[T any] struct {
+	encryptor Encryptor
+}
+
+func NewGenericEncryptor[T any](encryptor Encryptor) GenericEncryptor[T] {
+	return GenericEncryptor[T]{encryptor}
+}
+
+func (encryptor *GenericEncryptor[T]) Encrypt(ctx context.Context, data T, metadata Metadata) ([]byte, error) {
+	plaintext, err := encode.Encode(data)
+	if err != nil {
+		return nil, err
+	}
+
+	ciphertext, err := encryptor.encryptor.Encrypt(ctx, plaintext, metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	return ciphertext, nil
+}
+
+func (encryptor *GenericEncryptor[T]) Decrypt(ctx context.Context, ciphertext []byte, metadata Metadata) (result T, err error) {
+	plaintext, err := encryptor.encryptor.Decrypt(ctx, ciphertext, metadata)
+	if err != nil {
+		return result, err
+	}
+
+	result, err = encode.Decode[T](plaintext)
+	if err != nil {
+		return result, err
+	}
+
+	return result, nil
+}

--- a/pkg/cloudencrypt/generic_test.go
+++ b/pkg/cloudencrypt/generic_test.go
@@ -1,0 +1,49 @@
+package cloudencrypt_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/go-cloud-encrypt/internal/random"
+	"github.com/keboola/go-cloud-encrypt/pkg/cloudencrypt"
+)
+
+type myStruct struct {
+	Number int
+	Text   string
+}
+
+func TestGenericEncryptor(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	secretKey, err := random.SecretKey()
+	assert.NoError(t, err)
+
+	encryptor, err := cloudencrypt.NewNativeEncryptor(secretKey)
+	assert.NoError(t, err)
+
+	myStructEncryptor := cloudencrypt.NewGenericEncryptor[myStruct](encryptor)
+
+	meta := cloudencrypt.Metadata{}
+	meta["metakey"] = "metavalue"
+
+	data := myStruct{
+		Number: 42,
+		Text:   "Lorem ipsum",
+	}
+
+	ciphertext, err := myStructEncryptor.Encrypt(ctx, data, meta)
+	assert.NoError(t, err)
+
+	_, err = myStructEncryptor.Decrypt(ctx, ciphertext, cloudencrypt.Metadata{})
+	assert.ErrorContains(t, err, "cipher: message authentication failed")
+
+	decrypted, err := myStructEncryptor.Decrypt(ctx, ciphertext, meta)
+	assert.NoError(t, err)
+
+	assert.Equal(t, data, decrypted)
+}

--- a/pkg/cloudencrypt/logged_test.go
+++ b/pkg/cloudencrypt/logged_test.go
@@ -1,4 +1,4 @@
-package cloudencrypt
+package cloudencrypt_test
 
 import (
 	"bytes"
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keboola/go-cloud-encrypt/internal/random"
+	"github.com/keboola/go-cloud-encrypt/pkg/cloudencrypt"
 )
 
 func TestLoggedEncryptor(t *testing.T) {
@@ -20,22 +21,22 @@ func TestLoggedEncryptor(t *testing.T) {
 	secretKey, err := random.SecretKey()
 	assert.NoError(t, err)
 
-	nativeEncryptor, err := NewNativeEncryptor(secretKey)
+	nativeEncryptor, err := cloudencrypt.NewNativeEncryptor(secretKey)
 	assert.NoError(t, err)
 
 	var buffer bytes.Buffer
 	logger := log.New(&buffer, "", 0)
 
-	encryptor, err := NewLoggedEncryptor(ctx, nativeEncryptor, logger)
+	encryptor, err := cloudencrypt.NewLoggedEncryptor(ctx, nativeEncryptor, logger)
 	assert.NoError(t, err)
 
-	meta := Metadata{}
+	meta := cloudencrypt.Metadata{}
 	meta["metakey"] = "metavalue"
 
 	ciphertext, err := encryptor.Encrypt(ctx, []byte("Lorem ipsum"), meta)
 	assert.NoError(t, err)
 
-	_, err = encryptor.Decrypt(ctx, ciphertext, Metadata{})
+	_, err = encryptor.Decrypt(ctx, ciphertext, cloudencrypt.Metadata{})
 	assert.ErrorContains(t, err, "cipher: message authentication failed")
 
 	plaintext, err := encryptor.Decrypt(ctx, ciphertext, meta)

--- a/pkg/cloudencrypt/native_test.go
+++ b/pkg/cloudencrypt/native_test.go
@@ -1,4 +1,4 @@
-package cloudencrypt
+package cloudencrypt_test
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keboola/go-cloud-encrypt/internal/random"
+	"github.com/keboola/go-cloud-encrypt/pkg/cloudencrypt"
 )
 
 func TestNativeEncryptor(t *testing.T) {
@@ -17,16 +18,16 @@ func TestNativeEncryptor(t *testing.T) {
 	secretKey, err := random.SecretKey()
 	assert.NoError(t, err)
 
-	encryptor, err := NewNativeEncryptor(secretKey)
+	encryptor, err := cloudencrypt.NewNativeEncryptor(secretKey)
 	assert.NoError(t, err)
 
-	meta := Metadata{}
+	meta := cloudencrypt.Metadata{}
 	meta["metakey"] = "metavalue"
 
 	ciphertext, err := encryptor.Encrypt(ctx, []byte("Lorem ipsum"), meta)
 	assert.NoError(t, err)
 
-	_, err = encryptor.Decrypt(ctx, ciphertext, Metadata{})
+	_, err = encryptor.Decrypt(ctx, ciphertext, cloudencrypt.Metadata{})
 	assert.ErrorContains(t, err, "cipher: message authentication failed")
 
 	plaintext, err := encryptor.Decrypt(ctx, ciphertext, meta)


### PR DESCRIPTION
I realized it will be better to encrypt the whole token struct so I implemented very simple `GenericEncryptor` wrapper. The idea is that in dependencies we'll just have the normal `Encryptor` that accept `[]bytes` and then we'll wrap it with `GenericEncryptor` for the specific struct we need to encrypt.

Also black-box testing is better practice so I refactored all tests.