### PR TITLE
refactor: Split metadata encoding and serialization

### DIFF
--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -1,0 +1,39 @@
+package metadata
+
+import (
+	"bytes"
+	"encoding/gob"
+	"sort"
+
+	"github.com/pkg/errors"
+)
+
+// Encode converts a metadata map to byte slice.
+func Encode(data map[string]string) ([]byte, error) {
+	type pair struct {
+		Key   string
+		Value string
+	}
+
+	slice := make([]pair, len(data))
+	i := 0
+	for k, v := range data {
+		slice[i] = pair{
+			Key:   k,
+			Value: v,
+		}
+		i += 1
+	}
+
+	// Sort the slice to make the result deterministic
+	sort.Slice(slice, func(i, j int) bool { return slice[i].Key < slice[j].Key })
+
+	var buffer bytes.Buffer
+
+	err := gob.NewEncoder(&buffer).Encode(slice)
+	if err != nil {
+		return nil, errors.Wrapf(err, "gob encoder failed: %s", err.Error())
+	}
+
+	return buffer.Bytes(), nil
+}

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -1,0 +1,35 @@
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keboola/go-cloud-encrypt/internal/metadata"
+	"github.com/keboola/go-cloud-encrypt/internal/random"
+)
+
+func TestEncode(t *testing.T) {
+	t.Parallel()
+
+	secretKey, err := random.SecretKey()
+	assert.NoError(t, err)
+
+	data1 := make(map[string]string)
+	data1["test1"] = string(secretKey)
+	data1["test2"] = string(secretKey)
+
+	data2 := make(map[string]string)
+	data2["test2"] = string(secretKey)
+	data2["test1"] = string(secretKey)
+
+	encoded1, err := metadata.Encode(data1)
+	assert.NoError(t, err)
+	assert.NotNil(t, encoded1)
+
+	encoded2, err := metadata.Encode(data2)
+	assert.NoError(t, err)
+	assert.NotNil(t, encoded2)
+
+	assert.Equal(t, encoded1, encoded2)
+}

--- a/internal/serialize/serialize.go
+++ b/internal/serialize/serialize.go
@@ -1,22 +1,18 @@
-package encode
+package serialize
 
 import (
 	"bytes"
 	"compress/gzip"
-	"encoding/base64"
 	"encoding/gob"
 
 	"github.com/pkg/errors"
 )
 
-func Encode(data any) ([]byte, error) {
+func Serialize(data any) ([]byte, error) {
 	var buffer bytes.Buffer
 
-	// Base64 encode
-	encoder := base64.NewEncoder(base64.StdEncoding, &buffer)
-
 	// Gzip compress
-	writer := gzip.NewWriter(encoder)
+	writer := gzip.NewWriter(&buffer)
 
 	// gob encode
 	err := gob.NewEncoder(writer).Encode(data)
@@ -29,20 +25,14 @@ func Encode(data any) ([]byte, error) {
 		return nil, errors.Wrapf(err, "can't close gzip writer: %s", err.Error())
 	}
 
-	err = encoder.Close()
-	if err != nil {
-		return nil, errors.Wrapf(err, "base64 encoder failed: %s", err.Error())
-	}
-
 	return buffer.Bytes(), nil
 }
 
-func Decode[T any](data []byte) (decoded T, err error) {
-	// Base64 decode
-	decoder := base64.NewDecoder(base64.StdEncoding, bytes.NewReader(data))
+func Deserialize[T any](data []byte) (T, error) {
+	var decoded T
 
 	// Gzip uncompress
-	reader, err := gzip.NewReader(decoder)
+	reader, err := gzip.NewReader(bytes.NewReader(data))
 	if err != nil {
 		return decoded, errors.Wrapf(err, "can't create gzip reader: %s", err.Error())
 	}

--- a/internal/serialize/serialize_test.go
+++ b/internal/serialize/serialize_test.go
@@ -1,12 +1,12 @@
-package encode_test
+package serialize_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/keboola/go-cloud-encrypt/internal/encode"
 	"github.com/keboola/go-cloud-encrypt/internal/random"
+	"github.com/keboola/go-cloud-encrypt/internal/serialize"
 )
 
 func TestEncodeDecode(t *testing.T) {
@@ -18,11 +18,11 @@ func TestEncodeDecode(t *testing.T) {
 	data := make(map[string][]byte)
 	data["test"] = secretKey
 
-	encoded, err := encode.Encode(data)
+	encoded, err := serialize.Serialize(data)
 	assert.NoError(t, err)
 	assert.NotNil(t, encoded)
 
-	decoded, err := encode.Decode[map[string][]byte](encoded)
+	decoded, err := serialize.Deserialize[map[string][]byte](encoded)
 	assert.NoError(t, err)
 	assert.NotNil(t, decoded)
 

--- a/pkg/cloudencrypt/cached.go
+++ b/pkg/cloudencrypt/cached.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/dgraph-io/ristretto/v2"
 
-	"github.com/keboola/go-cloud-encrypt/internal/encode"
+	"github.com/keboola/go-cloud-encrypt/internal/metadata"
 )
 
 // CachedEncryptor wraps another Encryptor and adds a caching mechanism.
@@ -24,13 +24,13 @@ func NewCachedEncryptor(encryptor Encryptor, ttl time.Duration, cache *ristretto
 	}
 }
 
-func (encryptor *CachedEncryptor) Encrypt(ctx context.Context, plaintext []byte, metadata Metadata) ([]byte, error) {
-	key, err := encode.Encode(metadata)
+func (encryptor *CachedEncryptor) Encrypt(ctx context.Context, plaintext []byte, meta Metadata) ([]byte, error) {
+	key, err := metadata.Encode(meta)
 	if err != nil {
 		return nil, err
 	}
 
-	encryptedValue, err := encryptor.encryptor.Encrypt(ctx, plaintext, metadata)
+	encryptedValue, err := encryptor.encryptor.Encrypt(ctx, plaintext, meta)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +42,8 @@ func (encryptor *CachedEncryptor) Encrypt(ctx context.Context, plaintext []byte,
 	return encryptedValue, nil
 }
 
-func (encryptor *CachedEncryptor) Decrypt(ctx context.Context, ciphertext []byte, metadata Metadata) ([]byte, error) {
-	key, err := encode.Encode(metadata)
+func (encryptor *CachedEncryptor) Decrypt(ctx context.Context, ciphertext []byte, meta Metadata) ([]byte, error) {
+	key, err := metadata.Encode(meta)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (encryptor *CachedEncryptor) Decrypt(ctx context.Context, ciphertext []byte
 		return cached, nil
 	}
 
-	plaintext, err := encryptor.encryptor.Decrypt(ctx, ciphertext, metadata)
+	plaintext, err := encryptor.encryptor.Decrypt(ctx, ciphertext, meta)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudencrypt/dual.go
+++ b/pkg/cloudencrypt/dual.go
@@ -3,8 +3,8 @@ package cloudencrypt
 import (
 	"context"
 
-	"github.com/keboola/go-cloud-encrypt/internal/encode"
 	"github.com/keboola/go-cloud-encrypt/internal/random"
+	"github.com/keboola/go-cloud-encrypt/internal/serialize"
 )
 
 const (
@@ -46,7 +46,7 @@ func (encryptor *DualEncryptor) Encrypt(ctx context.Context, plaintext []byte, m
 	output[mapKeySecretKey] = encryptedSecretKey
 	output[mapKeyCipherText] = ciphertext
 
-	encoded, err := encode.Encode(output)
+	encoded, err := serialize.Serialize(output)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (encryptor *DualEncryptor) Encrypt(ctx context.Context, plaintext []byte, m
 }
 
 func (encryptor *DualEncryptor) Decrypt(ctx context.Context, ciphertext []byte, metadata Metadata) ([]byte, error) {
-	decoded, err := encode.Decode[map[string][]byte](ciphertext)
+	decoded, err := serialize.Deserialize[map[string][]byte](ciphertext)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudencrypt/gcp.go
+++ b/pkg/cloudencrypt/gcp.go
@@ -7,7 +7,7 @@ import (
 	"cloud.google.com/go/kms/apiv1/kmspb"
 	"github.com/pkg/errors"
 
-	"github.com/keboola/go-cloud-encrypt/internal/encode"
+	"github.com/keboola/go-cloud-encrypt/internal/metadata"
 )
 
 // GCPEncryptor Implements Encryptor using Google Cloud's Key Management Service.
@@ -28,8 +28,8 @@ func NewGCPEncryptor(ctx context.Context, keyID string) (*GCPEncryptor, error) {
 	}, nil
 }
 
-func (encryptor *GCPEncryptor) Encrypt(ctx context.Context, plaintext []byte, metadata Metadata) ([]byte, error) {
-	additionalData, err := encode.Encode(metadata)
+func (encryptor *GCPEncryptor) Encrypt(ctx context.Context, plaintext []byte, meta Metadata) ([]byte, error) {
+	additionalData, err := metadata.Encode(meta)
 	if err != nil {
 		return nil, err
 	}
@@ -48,8 +48,8 @@ func (encryptor *GCPEncryptor) Encrypt(ctx context.Context, plaintext []byte, me
 	return response.GetCiphertext(), nil
 }
 
-func (encryptor *GCPEncryptor) Decrypt(ctx context.Context, ciphertext []byte, metadata Metadata) ([]byte, error) {
-	additionalData, err := encode.Encode(metadata)
+func (encryptor *GCPEncryptor) Decrypt(ctx context.Context, ciphertext []byte, meta Metadata) ([]byte, error) {
+	additionalData, err := metadata.Encode(meta)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudencrypt/generic.go
+++ b/pkg/cloudencrypt/generic.go
@@ -3,7 +3,7 @@ package cloudencrypt
 import (
 	"context"
 
-	"github.com/keboola/go-cloud-encrypt/internal/encode"
+	"github.com/keboola/go-cloud-encrypt/internal/serialize"
 )
 
 type GenericEncryptor[T any] struct {
@@ -15,7 +15,7 @@ func NewGenericEncryptor[T any](encryptor Encryptor) *GenericEncryptor[T] {
 }
 
 func (encryptor *GenericEncryptor[T]) Encrypt(ctx context.Context, data T, metadata Metadata) ([]byte, error) {
-	plaintext, err := encode.Encode(data)
+	plaintext, err := serialize.Serialize(data)
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +34,7 @@ func (encryptor *GenericEncryptor[T]) Decrypt(ctx context.Context, ciphertext []
 		return result, err
 	}
 
-	result, err = encode.Decode[T](plaintext)
+	result, err = serialize.Deserialize[T](plaintext)
 	if err != nil {
 		return result, err
 	}

--- a/pkg/cloudencrypt/native.go
+++ b/pkg/cloudencrypt/native.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/keboola/go-cloud-encrypt/internal/encode"
+	"github.com/keboola/go-cloud-encrypt/internal/metadata"
 	"github.com/keboola/go-cloud-encrypt/internal/random"
 )
 
@@ -32,8 +32,8 @@ func NewNativeEncryptor(secretKey []byte) (*NativeEncryptor, error) {
 	}, nil
 }
 
-func (encryptor *NativeEncryptor) Encrypt(ctx context.Context, plaintext []byte, metadata Metadata) ([]byte, error) {
-	additionalData, err := encode.Encode(metadata)
+func (encryptor *NativeEncryptor) Encrypt(ctx context.Context, plaintext []byte, meta Metadata) ([]byte, error) {
+	additionalData, err := metadata.Encode(meta)
 	if err != nil {
 		return nil, err
 	}
@@ -47,8 +47,8 @@ func (encryptor *NativeEncryptor) Encrypt(ctx context.Context, plaintext []byte,
 	return encryptor.gcm.Seal(nonce, nonce, plaintext, additionalData), nil
 }
 
-func (encryptor *NativeEncryptor) Decrypt(ctx context.Context, ciphertext []byte, metadata Metadata) ([]byte, error) {
-	additionalData, err := encode.Encode(metadata)
+func (encryptor *NativeEncryptor) Decrypt(ctx context.Context, ciphertext []byte, meta Metadata) ([]byte, error) {
+	additionalData, err := metadata.Encode(meta)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Encryption wasn't working correctly on dev stack because encoding the metadata didn't always provide the same result.

Changes:
- Added separate function to deterministically encode metadata
  - Metadata encoding no longer uses gzip since it isn't deterministic and metadata are small
  - Metadata encoding no longer uses base64 because it isn't needed
  - Metadata map is converted to slice to make sure the result is deterministic
  - We could write a reverse function but we have no use for it
- Renamed original `Encode` and `Decode` functions to `Serialize` and `Deserialize`
  - This is still used by `GenericEncryptor` and `DualEncryptor`
  - We don't care whether the serialized value is deterministic, we just need to be able to deserialize
  - Serialization no longer uses base64 because it isn't needed