### PR TITLE
refactor: Rename classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Library designed for symmetric encryption using AWS, GCP or Azure services.
 
 ## Usage
 
-It is recommended to use the `DualEncryptor` which encrypts the given input using `NativeEncryptor` and then the secret
+It is recommended to use the `AESWrapEncryptor` which encrypts the given input using `AESEncryptor` and then the secret
 key using the given encryptor. You may also want to use `CachedEncryptor` to avoid decrypting the same value repeatedly.
 
 ```go
@@ -40,7 +40,7 @@ func CreateEncryptor(ctx context.Context) (*cloudencrypt.Encryptor, error) {
 		return nil, err
 	}
 
-	encryptor, err = cloudencrypt.NewDualEncryptor(ctx, encryptor)
+	encryptor, err = cloudencrypt.NewAESWrapEncryptor(ctx, encryptor)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudencrypt/aes.go
+++ b/pkg/cloudencrypt/aes.go
@@ -11,19 +11,19 @@ import (
 	"github.com/keboola/go-cloud-encrypt/internal/random"
 )
 
-// NativeEncryptor Implements Encryptor without using any cloud service.
-type NativeEncryptor struct {
+// AESEncryptor Implements Encryptor without using any cloud service.
+type AESEncryptor struct {
 	gcm       cipher.AEAD
 	generator NonceGenerator
 }
 
 type NonceGenerator func(int) ([]byte, error)
 
-func NewNativeEncryptor(secretKey []byte) (*NativeEncryptor, error) {
-	return NewNativeEncryptorWithNonceGenerator(secretKey, random.Bytes)
+func NewAESEncryptor(secretKey []byte) (*AESEncryptor, error) {
+	return NewAESEncryptorWithNonceGenerator(secretKey, random.Bytes)
 }
 
-func NewNativeEncryptorWithNonceGenerator(secretKey []byte, generator NonceGenerator) (*NativeEncryptor, error) {
+func NewAESEncryptorWithNonceGenerator(secretKey []byte, generator NonceGenerator) (*AESEncryptor, error) {
 	if generator == nil {
 		return nil, errors.New("missing nonce generator")
 	}
@@ -38,13 +38,13 @@ func NewNativeEncryptorWithNonceGenerator(secretKey []byte, generator NonceGener
 		return nil, errors.Wrapf(err, "can't create gcm: %s", err.Error())
 	}
 
-	return &NativeEncryptor{
+	return &AESEncryptor{
 		gcm:       gcm,
 		generator: generator,
 	}, nil
 }
 
-func (encryptor *NativeEncryptor) Encrypt(ctx context.Context, plaintext []byte, meta Metadata) ([]byte, error) {
+func (encryptor *AESEncryptor) Encrypt(ctx context.Context, plaintext []byte, meta Metadata) ([]byte, error) {
 	additionalData, err := json.Marshal(meta)
 	if err != nil {
 		return nil, err
@@ -59,7 +59,7 @@ func (encryptor *NativeEncryptor) Encrypt(ctx context.Context, plaintext []byte,
 	return encryptor.gcm.Seal(nonce, nonce, plaintext, additionalData), nil
 }
 
-func (encryptor *NativeEncryptor) Decrypt(ctx context.Context, ciphertext []byte, meta Metadata) ([]byte, error) {
+func (encryptor *AESEncryptor) Decrypt(ctx context.Context, ciphertext []byte, meta Metadata) ([]byte, error) {
 	additionalData, err := json.Marshal(meta)
 	if err != nil {
 		return nil, err
@@ -77,6 +77,6 @@ func (encryptor *NativeEncryptor) Decrypt(ctx context.Context, ciphertext []byte
 	return plaintext, nil
 }
 
-func (encryptor *NativeEncryptor) Close() error {
+func (encryptor *AESEncryptor) Close() error {
 	return nil
 }

--- a/pkg/cloudencrypt/aes_test.go
+++ b/pkg/cloudencrypt/aes_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/keboola/go-cloud-encrypt/pkg/cloudencrypt"
 )
 
-func TestDualEncryptor(t *testing.T) {
+func TestAESEncryptor(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -19,10 +19,7 @@ func TestDualEncryptor(t *testing.T) {
 	secretKey, err := random.SecretKey()
 	require.NoError(t, err)
 
-	nativeEncryptor, err := cloudencrypt.NewNativeEncryptor(secretKey)
-	require.NoError(t, err)
-
-	encryptor, err := cloudencrypt.NewDualEncryptor(ctx, nativeEncryptor)
+	encryptor, err := cloudencrypt.NewAESEncryptor(secretKey)
 	require.NoError(t, err)
 
 	meta := cloudencrypt.Metadata{}

--- a/pkg/cloudencrypt/aes_wrap_test.go
+++ b/pkg/cloudencrypt/aes_wrap_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/keboola/go-cloud-encrypt/pkg/cloudencrypt"
 )
 
-func TestNativeEncryptor(t *testing.T) {
+func TestAESWrapEncryptor(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -19,7 +19,10 @@ func TestNativeEncryptor(t *testing.T) {
 	secretKey, err := random.SecretKey()
 	require.NoError(t, err)
 
-	encryptor, err := cloudencrypt.NewNativeEncryptor(secretKey)
+	aesEncryptor, err := cloudencrypt.NewAESEncryptor(secretKey)
+	require.NoError(t, err)
+
+	encryptor, err := cloudencrypt.NewAESWrapEncryptor(ctx, aesEncryptor)
 	require.NoError(t, err)
 
 	meta := cloudencrypt.Metadata{}

--- a/pkg/cloudencrypt/azure_test.go
+++ b/pkg/cloudencrypt/azure_test.go
@@ -29,7 +29,7 @@ func TestAzureEncryptor(t *testing.T) {
 	azureEncryptor, err := cloudencrypt.NewAzureEncryptor(ctx, vaultURL, keyName)
 	require.NoError(t, err)
 
-	encryptor, err := cloudencrypt.NewDualEncryptor(ctx, azureEncryptor)
+	encryptor, err := cloudencrypt.NewAESWrapEncryptor(ctx, azureEncryptor)
 	require.NoError(t, err)
 
 	meta := cloudencrypt.Metadata{}

--- a/pkg/cloudencrypt/cached_test.go
+++ b/pkg/cloudencrypt/cached_test.go
@@ -24,13 +24,13 @@ func TestCachedEncryptor(t *testing.T) {
 	secretKey, err := random.SecretKey()
 	require.NoError(t, err)
 
-	nativeEncryptor, err := cloudencrypt.NewNativeEncryptor(secretKey)
+	aesEncryptor, err := cloudencrypt.NewAESEncryptor(secretKey)
 	require.NoError(t, err)
 
 	var buffer bytes.Buffer
 	logger := log.New(&buffer, "", 0)
 
-	logEncryptor, err := cloudencrypt.NewLoggedEncryptor(ctx, nativeEncryptor, logger)
+	logEncryptor, err := cloudencrypt.NewLoggedEncryptor(ctx, aesEncryptor, logger)
 	require.NoError(t, err)
 
 	config := &ristretto.Config[[]byte, []byte]{

--- a/pkg/cloudencrypt/generic_test.go
+++ b/pkg/cloudencrypt/generic_test.go
@@ -24,7 +24,7 @@ func TestGenericEncryptor(t *testing.T) {
 	secretKey, err := random.SecretKey()
 	require.NoError(t, err)
 
-	encryptor, err := cloudencrypt.NewNativeEncryptor(secretKey)
+	encryptor, err := cloudencrypt.NewAESEncryptor(secretKey)
 	require.NoError(t, err)
 
 	myStructEncryptor := cloudencrypt.NewGenericEncryptor[myStruct](encryptor)

--- a/pkg/cloudencrypt/logged_test.go
+++ b/pkg/cloudencrypt/logged_test.go
@@ -22,13 +22,13 @@ func TestLoggedEncryptor(t *testing.T) {
 	secretKey, err := random.SecretKey()
 	require.NoError(t, err)
 
-	nativeEncryptor, err := cloudencrypt.NewNativeEncryptor(secretKey)
+	aesEncryptor, err := cloudencrypt.NewAESEncryptor(secretKey)
 	require.NoError(t, err)
 
 	var buffer bytes.Buffer
 	logger := log.New(&buffer, "", 0)
 
-	encryptor, err := cloudencrypt.NewLoggedEncryptor(ctx, nativeEncryptor, logger)
+	encryptor, err := cloudencrypt.NewLoggedEncryptor(ctx, aesEncryptor, logger)
 	require.NoError(t, err)
 
 	meta := cloudencrypt.Metadata{}

--- a/pkg/cloudencrypt/multiplex_test.go
+++ b/pkg/cloudencrypt/multiplex_test.go
@@ -21,10 +21,10 @@ func TestMultiplexEncryptor(t *testing.T) {
 		secretKey, err := random.SecretKey()
 		require.NoError(t, err)
 
-		nativeEncryptor, err := cloudencrypt.NewNativeEncryptor(secretKey)
+		aesEncryptor, err := cloudencrypt.NewAESEncryptor(secretKey)
 		require.NoError(t, err)
 
-		return cloudencrypt.NewPrefixEncryptor(ctx, nativeEncryptor, prefix)
+		return cloudencrypt.NewPrefixEncryptor(ctx, aesEncryptor, prefix)
 	}
 
 	newEncryptor, err := encryptorFactory(ctx, []byte("New::"))

--- a/pkg/cloudencrypt/prefix_test.go
+++ b/pkg/cloudencrypt/prefix_test.go
@@ -20,10 +20,10 @@ func TestPrefixEncryptor(t *testing.T) {
 	secretKey, err := random.SecretKey()
 	require.NoError(t, err)
 
-	nativeEncryptor, err := cloudencrypt.NewNativeEncryptor(secretKey)
+	aesEncryptor, err := cloudencrypt.NewAESEncryptor(secretKey)
 	require.NoError(t, err)
 
-	encryptor, err := cloudencrypt.NewPrefixEncryptor(ctx, nativeEncryptor, []byte("Prefix::"))
+	encryptor, err := cloudencrypt.NewPrefixEncryptor(ctx, aesEncryptor, []byte("Prefix::"))
 	require.NoError(t, err)
 
 	meta := cloudencrypt.Metadata{}


### PR DESCRIPTION
I decided to rename the native and dual encryptor. The reasoning is that if we later decide to use something else than aes cipher the naming will be clearer. Also the dual encryptor is currently hardcoded to use aes internally so it makes sense to rename it as well.