### PR TITLE
fix: Base64Encoder

### DIFF
--- a/pkg/cloudencrypt/base64.go
+++ b/pkg/cloudencrypt/base64.go
@@ -28,11 +28,12 @@ func (encryptor *Base64Encryptor) Encrypt(ctx context.Context, plaintext []byte,
 
 func (encryptor *Base64Encryptor) Decrypt(ctx context.Context, ciphertext []byte, metadata Metadata) ([]byte, error) {
 	dst := make([]byte, base64.StdEncoding.DecodedLen(len(ciphertext)))
-	if _, err := base64.StdEncoding.Decode(dst, ciphertext); err != nil {
+	n, err := base64.StdEncoding.Decode(dst, ciphertext)
+	if err != nil {
 		return nil, err
 	}
 
-	plaintext, err := encryptor.encryptor.Decrypt(ctx, dst, metadata)
+	plaintext, err := encryptor.encryptor.Decrypt(ctx, dst[:n], metadata)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudencrypt/base64_test.go
+++ b/pkg/cloudencrypt/base64_test.go
@@ -29,7 +29,7 @@ func TestBase64Encryptor(t *testing.T) {
 	meta := cloudencrypt.Metadata{}
 	meta["metakey"] = "metavalue"
 
-	ciphertext, err := encryptor.Encrypt(ctx, []byte("Lorem ipsum"), meta)
+	ciphertext, err := encryptor.Encrypt(ctx, []byte(" "), meta)
 	require.NoError(t, err)
 
 	_, err = base64.StdEncoding.DecodeString(string(ciphertext))
@@ -41,5 +41,5 @@ func TestBase64Encryptor(t *testing.T) {
 	plaintext, err := encryptor.Decrypt(ctx, ciphertext, meta)
 	require.NoError(t, err)
 
-	assert.Equal(t, []byte("Lorem ipsum"), plaintext)
+	assert.Equal(t, []byte(" "), plaintext)
 }

--- a/pkg/cloudencrypt/prefix.go
+++ b/pkg/cloudencrypt/prefix.go
@@ -14,7 +14,8 @@ type PrefixEncryptor struct {
 
 func NewPrefixEncryptor(encryptor Encryptor, prefix []byte) (*PrefixEncryptor, error) {
 	return &PrefixEncryptor{
-		encryptor: encryptor, prefix: prefix,
+		encryptor: encryptor,
+		prefix:    prefix,
 	}, nil
 }
 


### PR DESCRIPTION
DecodedLen returns the maximum length the decoded value can be but it is necessary to cut the actual value to the `n` characters returned by `Decode`.